### PR TITLE
[fix] Added missing displayName assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,10 @@ export default function addhoc(renderFn, name = 'WithHOC', ...extraHOCArgs) {
     // Also hoist statics onto forward ref for convenience
     hoistNonReactStatics(forwardRef, WrappedComponent);
 
+    // Wrap display name per
+    // https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools
+    forwardRef.displayName = `forwardRef(${name}/${getDisplayName(WrappedComponent)})`;
+
     return forwardRef;
   };
 }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ export default function addhoc(renderFn, name = 'WithHOC', ...extraHOCArgs) {
 
     // Wrap display name per
     // https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools
-    forwardRef.displayName = `forwardRef(${name}/${getDisplayName(WrappedComponent)})`;
+    forwardRef.displayName = `ForwardRef(${name}/${getDisplayName(WrappedComponent)})`;
 
     return forwardRef;
   };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,6 +73,28 @@ describe('addhoc', function () {
     assume(tree.exists('WithDiv(TestComponent)')).is.true();
   });
 
+  it('arguments the displayName of the returned Component when a custom HOC name is set', function () {
+    const TestComponent = () => <div />;
+    const withDiv = addhoc(getWrappedComponent =>
+      <div>
+        { getWrappedComponent() }
+      </div>, 'WithDiv');
+
+    const TestComponentWithDiv = withDiv(TestComponent);
+    assume(TestComponentWithDiv.displayName).equals('forwardRef(WithDiv/TestComponent)');
+  });
+
+  it('arguments the displayName of the returned Component when no HOC name is set', function () {
+    const TestComponent = () => <div/>;
+    const withDiv = addhoc(getWrappedComponent =>
+      <div>
+        { getWrappedComponent() }
+      </div>);
+
+    const TestComponentWithDiv = withDiv(TestComponent);
+    assume(TestComponentWithDiv.displayName).equals('forwardRef(WithHOC/TestComponent)');
+  });
+
   it('can create a HOC that uses the React 16 context API', function () {
     const TestComponent = props => <span>{ props.value }</span>;
     TestComponent.propTypes = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,7 @@ describe('addhoc', function () {
     assume(tree.exists('WithDiv(TestComponent)')).is.true();
   });
 
-  it('arguments the displayName of the returned Component when a custom HOC name is set', function () {
+  it('augments the displayName of the returned Component when a custom HOC name is set', function () {
     const TestComponent = () => <div />;
     const withDiv = addhoc(getWrappedComponent =>
       <div>
@@ -84,7 +84,7 @@ describe('addhoc', function () {
     assume(TestComponentWithDiv.displayName).equals('ForwardRef(WithDiv/TestComponent)');
   });
 
-  it('arguments the displayName of the returned Component when no HOC name is set', function () {
+  it('augments the displayName of the returned Component when no HOC name is set', function () {
     const TestComponent = () => <div/>;
     const withDiv = addhoc(getWrappedComponent =>
       <div>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,7 +81,7 @@ describe('addhoc', function () {
       </div>, 'WithDiv');
 
     const TestComponentWithDiv = withDiv(TestComponent);
-    assume(TestComponentWithDiv.displayName).equals('forwardRef(WithDiv/TestComponent)');
+    assume(TestComponentWithDiv.displayName).equals('ForwardRef(WithDiv/TestComponent)');
   });
 
   it('arguments the displayName of the returned Component when no HOC name is set', function () {
@@ -92,7 +92,7 @@ describe('addhoc', function () {
       </div>);
 
     const TestComponentWithDiv = withDiv(TestComponent);
-    assume(TestComponentWithDiv.displayName).equals('forwardRef(WithHOC/TestComponent)');
+    assume(TestComponentWithDiv.displayName).equals('ForwardRef(WithHOC/TestComponent)');
   });
 
   it('can create a HOC that uses the React 16 context API', function () {


### PR DESCRIPTION
As per title, correctly assign a displayName to the returned `forwardRef` as per https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools